### PR TITLE
Add support for no hotplug feature in libThymesisFlow

### DIFF
--- a/libthymesisflow/Makefile
+++ b/libthymesisflow/Makefile
@@ -74,6 +74,14 @@ cmds: $(CMD_BIN)
 
 .PHONY: all clean clean_tests cmds tests docs
 
+cscope:
+	find ./* -type f \( -name \*.c -o -name \*.h \) > ./cscope.files
+	cscope -b -q
 
 clean:
 	rm -rf $(OUT_DIRS)
+	rm -rf cscope.files
+	rm -rf cscope.in.out
+	rm -rf cscope.out
+	rm -rf cscope.po.out
+

--- a/libthymesisflow/README.md
+++ b/libthymesisflow/README.md
@@ -111,7 +111,8 @@ sudo ./bin/thymesisf-cli attach-compute \
     --afu <AFU_NAME> \
     --cid <CIRCUIT_ID> \
     --size <MEMORY_SIZE> \
-    --ea <EFFECTIVE_ADDRESS>
+    --ea <EFFECTIVE_ADDRESS> \
+    [--no-hotplug]
 ```
 
 Where:
@@ -120,6 +121,7 @@ Where:
 * `CIRCUIT_ID` is an alphanumeric string representing your connection
 * `MEMORY_SIZE` represents the amount of memory (in bytes) to be reserved. This needs to be a multiple of 256 MB
 * `EFFECTIVE_ADDRESS` address returned as `EA` during the [memory side setup](# Setup Memory side)
+* `--no-hotplug` attaches the memory without actual hotplug to the running Linux kenrel
 
 #### Stats counters
 

--- a/libthymesisflow/cmd/thymesisf-cli.c
+++ b/libthymesisflow/cmd/thymesisf-cli.c
@@ -76,11 +76,13 @@ void helper_compute_attach() {
     fprintf(stderr,
             "    --ea EFFECTIVE_ADDRESS\n\t\t effective address printed "
             "by the lender\n");
+    fprintf(stderr, "    --no-hotplug\n\t\t attach memory without hotplugging to Linux\n");
+
 }
 
 int handle_compute_attach(const char *cid, const char *afu,
                           const iport_list *pl, const uint64_t size,
-                          const u_int64_t ea, const char *sock_path) {
+                          const u_int64_t ea, const char *sock_path, int no_hotplug) {
     if (cid == NULL || strlen(cid) == 0 || size == 0 || pl == NULL ||
         afu == NULL || strlen(afu) == 0 || ea == 0) {
         helper_compute_attach();
@@ -97,7 +99,7 @@ int handle_compute_attach(const char *cid, const char *afu,
     log_info("attaching compute - size: %lu - using effective address: %lu\n",
              size, ea);
 
-    pmessage cresp = send_attach_compute_msg(cid, afu, pl, size, ea, sock_path);
+    pmessage cresp = send_attach_compute_msg(cid, afu, pl, size, ea, no_hotplug, sock_path);
 
     if (cresp.status == 100) {
         log_info("Successfully attached compute connection\n");
@@ -198,12 +200,14 @@ int main(int argc, char **argv) {
     uint64_t ea = 0;
     char *sock_path = NULL;
     iport_list *pl = NULL;
+    static int no_hotplug = 0;
 
     static struct option long_options[] = {
         {"size", required_argument, 0, 's'},
         {"afu", required_argument, 0, 'a'},
         {"ea", required_argument, 0, 'e'},
         {"cid", required_argument, 0, 'c'},
+        {"no-hotplug", no_argument, &no_hotplug, 1},
         //{"port",required_argument,0,'p'},
     };
 
@@ -244,7 +248,7 @@ int main(int argc, char **argv) {
     if (strcmp("attach-memory", command) == 0) {
         return handle_memory_attach(cid, afu, pl, size, sock_path);
     } else if (strcmp("attach-compute", command) == 0) {
-        return handle_compute_attach(cid, afu, pl, size, ea, sock_path);
+        return handle_compute_attach(cid, afu, pl, size, ea, sock_path, no_hotplug);
     } else if (strcmp("detach-memory", command) == 0) {
         return handle_memory_detach(cid, sock_path);
     } else if (strcmp("detach-compute", command) == 0) {

--- a/libthymesisflow/include/client.h
+++ b/libthymesisflow/include/client.h
@@ -50,12 +50,13 @@ pmessage send_attach_memory_msg(const char *circuitid, const char *afu,
  * single port supported)
  * @param[in] size: size of memory to be allocated
  * @param[in] ea: effective address to be passed to the AFU during the setup
+ * @param[in] no_hotplug: do not hotploug memory
  * @param[in] sock_path: path to the linux socket
  * @param[out] pmessage unmarshalled response from the server
  */
 pmessage send_attach_compute_msg(const char *circuitid, const char *afu,
                                  const iport_list *ports, const uint64_t size,
-                                 const uint64_t ea, const char *sock_path);
+                                 const uint64_t ea, int no_hotplug, const char *sock_path);
 
 /**
  *  Send detachment request to the memory node daemon through the linux socket

--- a/libthymesisflow/include/connection.h
+++ b/libthymesisflow/include/connection.h
@@ -65,6 +65,7 @@ struct connection_s {
     uint64_t size;
     unsigned char *ea;
     struct connection_s *next;
+    int no_hotplug;
 
 #ifndef MOCK
     ocxl_afu_h afu;
@@ -121,10 +122,11 @@ int free_conn(connection *conn);
  * @param[in] circuit_id: circuit identifier
  * @param[in] afu_name: AFU to be used
  * @param[in] size: disaggregated memory size
+ * @param[in] no_hotplug: no_hotplug flag value
  * @param[out] connection: connection to be freed
  */
 connection *new_conn(const char *circuit_id, const char *afu_name,
-                     const uint64_t size);
+                     const uint64_t size, int no_hotplug);
 
 int setup_afu_compute(connection *conn, uint64_t effective_addr,
                       iport_list *ports);

--- a/libthymesisflow/include/proto.h
+++ b/libthymesisflow/include/proto.h
@@ -34,6 +34,7 @@ typedef struct proto_response {
     int status;
     uint64_t size;
     uint64_t ea;
+    int no_hotplug;
 } pmessage;
 
 /**
@@ -109,11 +110,12 @@ char *marshal_attach_memory_request(const char *circuitid, const char *afu,
  * @param[in] ports: AFU port to be used
  * @param[in] size: memory allocation size (in bytes)
  * @param[in] ea: effective address used for memory access translation
+ * @param[in] no_hotplug: don't hoplug memory
  * @param[out] msg: array containing the marshalled request
  */
 char *marshal_attach_compute_request(const char *circuitid, const char *afu,
                                      const iport_list *ports,
-                                     const uint64_t memsize, const uint64_t ea);
+                                     const uint64_t memsize, const uint64_t ea, int no_hotplug);
 
 /**
  * Marshal request to tear down a thymesisflow on memory-stealing node

--- a/libthymesisflow/include/protoconst.h
+++ b/libthymesisflow/include/protoconst.h
@@ -22,10 +22,10 @@
 
 Possible messages:
 
- - | circuitid | memory    | afu | size |
- - | circuitid | compute   | afu | size | ea |
- - | circuitid | mresponse | afu |      | ea | error |
- - | circuitid | cresponse | afu | size |    | error |
+ - | circuitid | memory    | afu | port | size |
+ - | circuitid | compute   | afu | port | size | ea | no_hotplug |
+ - | circuitid | mresponse | afu |      |      | ea |            | error |
+ - | circuitid | cresponse | afu |      | size |    |            | error |
 
 */
 
@@ -66,6 +66,11 @@ Possible messages:
  */
 #define EA_SIZE sizeof(uint64_t)
 
+/*! \def NO_HOTPLUG_SIZE
+ * \brief size of the no_hotplug flag field
+ */
+#define NO_HOTPLUG_SIZE sizeof(int)
+
 /*! \def ERROR_SIZE
  * \brief maximum size for the error section
  */
@@ -76,7 +81,7 @@ Possible messages:
  */
 #define MSG_SIZE                                                               \
     CIRCUIT_ID_SIZE + MSGTYPE_SIZE + AFUNAME_SIZE + IPORT_SIZE + MEM_SIZE +    \
-        EA_SIZE + ERROR_SIZE
+        EA_SIZE + ERROR_SIZE + NO_HOTPLUG_SIZE
 
 #define CIRCUIT_ID_OFFSET 0
 
@@ -90,7 +95,9 @@ Possible messages:
 
 #define EA_OFFSET MEM_SIZE_OFFSET + MEM_SIZE
 
-#define ERROR_OFFSET EA_OFFSET + EA_SIZE
+#define NO_HOTPLUG_OFFSET EA_OFFSET + EA_SIZE
+
+#define ERROR_OFFSET NO_HOTPLUG_OFFSET + NO_HOTPLUG_SIZE
 
 #define MEMORY_ATTACH "memory_attach"
 

--- a/libthymesisflow/include/thymesisflow.h
+++ b/libthymesisflow/include/thymesisflow.h
@@ -76,7 +76,7 @@ int attach_memory(const char *circuit_id, const char *afu_name,
  */
 int attach_compute(const char *circuit_id, const char *afu_name,
                    iport_list *ports, const uint64_t effective_addr,
-                   const uint64_t size);
+                   const uint64_t size, int no_hotplug);
 /**
  * Disconnect and free allocated memory
  *

--- a/libthymesisflow/src/client.c
+++ b/libthymesisflow/src/client.c
@@ -75,9 +75,9 @@ pmessage send_attach_memory_msg(const char *circuitid, const char *afu,
 
 pmessage send_attach_compute_msg(const char *circuitid, const char *afu,
                                  const iport_list *ports, const uint64_t size,
-                                 const uint64_t ea, const char *sock_path) {
+                                 const uint64_t ea, int no_hotplug, const char *sock_path) {
 
-    char *msg = marshal_attach_compute_request(circuitid, afu, ports, size, ea);
+    char *msg = marshal_attach_compute_request(circuitid, afu, ports, size, ea, no_hotplug);
 
     pmessage rsp = send_cmd(msg, sock_path);
 

--- a/libthymesisflow/src/connection.c
+++ b/libthymesisflow/src/connection.c
@@ -27,11 +27,12 @@ uint64_t calculate_seg_offset(const uint64_t ea_base, const uint64_t seg_offset,
 }
 
 connection *new_conn(const char *circuit_id, const char *afu_name,
-                     const uint64_t size) {
+                     const uint64_t size, int no_hotplug) {
     connection *conn = (connection *)malloc(sizeof(connection));
     memcpy(conn->circuit_id, circuit_id, CIRCUIT_ID_SIZE);
     strncpy(conn->afu_name, afu_name, AFUNAME_SIZE);
     conn->size = size;
+    conn->no_hotplug = no_hotplug;
     conn->next = NULL;
 #ifndef MOCK
     conn->stat_tid = NULL;

--- a/libthymesisflow/src/proto.c
+++ b/libthymesisflow/src/proto.c
@@ -202,6 +202,22 @@ int set_ea(char *msg, uint64_t ea) {
     return 0;
 }
 
+int set_no_hotplug(char *msg, int no_hotplug) {
+    if (msg == NULL)
+        return ERR_MSGNULL;
+    if (no_hotplug > 1 || no_hotplug < 0)
+        return ERR_INT_PARAM;
+
+    memcpy(msg + NO_HOTPLUG_OFFSET, &no_hotplug, NO_HOTPLUG_SIZE);
+    return 0;
+}
+
+int get_no_hotplug(const char *msg) {
+    int no_hotplug = 0;
+    memcpy(&no_hotplug, msg + NO_HOTPLUG_OFFSET, NO_HOTPLUG_SIZE);
+    return no_hotplug;
+}
+
 void set_status(char *msg, int status) {
 
     log_info("setting status: %d\n", status);
@@ -311,12 +327,15 @@ char *proto_attach_compute(const char *msg) {
 
     uint64_t ea = get_ea(msg);
 
+    int no_hotplug = get_no_hotplug(msg);
+
     // uint64_t memsize = get_size(msg);
 
     log_info("requested compute mode - size %lu - effective address: %lu \n",
              size, ea);
 
-    int err = attach_compute(circuit_id, afu_name, ports, ea, size);
+    int err = attach_compute(circuit_id, afu_name, ports, ea, size, no_hotplug);
+
     // error check
     char *response_msg = (char *)malloc(sizeof(char) * MSG_SIZE);
 
@@ -439,7 +458,8 @@ char *marshal_attach_memory_request(const char *circuit_id, const char *afu,
 char *marshal_attach_compute_request(const char *circuit_id, const char *afu,
                                      const iport_list *ports,
                                      const uint64_t memsize,
-                                     const uint64_t ea) {
+                                     const uint64_t ea,
+                                     int no_hotplug) {
     char *request_msg = (char *)malloc(sizeof(char) * MSG_SIZE);
     if (set_circuitid(request_msg, circuit_id) < 0)
         log_warn("error setting message circuit id\n");
@@ -450,6 +470,7 @@ char *marshal_attach_compute_request(const char *circuit_id, const char *afu,
     set_iports(request_msg, ports);
     set_size(request_msg, memsize);
     set_ea(request_msg, ea);
+    set_no_hotplug(request_msg, no_hotplug);
     return request_msg;
 }
 
@@ -480,6 +501,7 @@ void unmarshal_response(char *msg, pmessage *rsp) {
     rsp->size = get_size(msg);
     rsp->ea = get_ea(msg);
     rsp->status = get_status(msg);
+    rsp->no_hotplug = get_no_hotplug(msg);
     free(afu_name);
     free(circuit_id);
 }


### PR DESCRIPTION
This Pull request adds support to the no-hotplug flag that can be used to attach memory to a compute node without having to hotplug it to the running Linux kernel. This feature is quite useful when experimenting with alternative ways of usind remote/disaggregated memory.
